### PR TITLE
Make account optional in the Arn

### DIFF
--- a/src/arn/__init__.py
+++ b/src/arn/__init__.py
@@ -9,7 +9,7 @@ BASE_PATTERN = re.compile(
     r"(?P<partition>.+?):"
     r"(?P<service>.+?):"
     r"(?P<region>.*?):"
-    r"(?P<account>.+?):"
+    r"(?P<account>.*?):"
     r"(?P<rest>.*)$"
 )
 

--- a/tests/test_arn_s3.py
+++ b/tests/test_arn_s3.py
@@ -8,13 +8,13 @@ def test_parses_access_point_arn(make_arn):
 
 
 def test_parses_bucket_arn(make_arn):
-    arn = make_arn("s3", "foo", region='', account='')
+    arn = make_arn("s3", "foo", region="", account="")
     result = s3.BucketArn(arn)
     assert result.name == "foo"
 
 
 def test_parses_object_arn(make_arn):
-    arn = make_arn("s3", "foo/bar", region='', account='')
+    arn = make_arn("s3", "foo/bar", region="", account="")
     result = s3.ObjectArn(arn)
     assert result.bucket_name == "foo"
     assert result.object_name == "bar"

--- a/tests/test_arn_s3.py
+++ b/tests/test_arn_s3.py
@@ -8,13 +8,13 @@ def test_parses_access_point_arn(make_arn):
 
 
 def test_parses_bucket_arn(make_arn):
-    arn = make_arn("s3", "foo")
+    arn = make_arn("s3", "foo", region='', account='')
     result = s3.BucketArn(arn)
     assert result.name == "foo"
 
 
 def test_parses_object_arn(make_arn):
-    arn = make_arn("s3", "foo/bar")
+    arn = make_arn("s3", "foo/bar", region='', account='')
     result = s3.ObjectArn(arn)
     assert result.bucket_name == "foo"
     assert result.object_name == "bar"


### PR DESCRIPTION
S3 buckets do not have the account in the ARN

This should fix this error:

```python
>>> from arn.s3 import BucketArn
>>> BucketArn('arn:aws:s3:::bucket_name')

Traceback (most recent call last):
  File ".../lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3417, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-7f227902d54d>", line 1, in <module>
    BucketArn('arn:aws:s3:::bucket_name')
  File "<string>", line 8, in __init__
  File ".../lib/python3.8/site-packages/arn/__init__.py", line 96, in __post_init__
    raise InvalidArnException(arn)
arn.InvalidArnException: arn:aws:s3:::bucket_name is not a valid ARN
```