### PR TITLE
Remove `annotations` future import since it's 3.7+ only

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[isort]
+known_first_party=arn

--- a/src/arn/__init__.py
+++ b/src/arn/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import re
 from typing import Any, ClassVar, Match, Optional, Pattern, Set, Union

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import webbrowser
+from pathlib import Path
 
 from invoke import task
 


### PR DESCRIPTION
This import isn't necessary, all annotations are already imported as values at runtime.

Closes #11.

Also fixes import order in `tasks.py` because isort started complaining.