### PR TITLE
Add support for new ECS ARN format

### DIFF
--- a/src/arn/ecs.py
+++ b/src/arn/ecs.py
@@ -15,7 +15,7 @@ class NewOldEcsArnMixin:
         Tries to match a new-style ARN with cluster name and falls back to matching
         the ARN without the cluster name.
 
-        .. _both ARN formats: https://www.amazonaws.cn/en/new/2018/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
+        .. _both ARN formats: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
         """
         match = self.REST_PATTERN_WITH_CLUSTER.match(rest)
         if match:
@@ -54,7 +54,7 @@ class ContainerInstanceArn(NewOldEcsArnMixin, Arn):
         If the ARN was originally parsed with the cluster name, it will be added to
         the formatted rest.
 
-        .. _both ARN formats: https://www.amazonaws.cn/en/new/2018/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
+        .. _both ARN formats: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
         """
         if self.cluster:
             return f"container-instance/{self.cluster}/{self.id}"
@@ -81,7 +81,7 @@ class ServiceArn(NewOldEcsArnMixin, Arn):
         If the ARN was originally parsed with the cluster name, it will be added to
         the formatted rest.
 
-        .. _both ARN formats: https://www.amazonaws.cn/en/new/2018/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
+        .. _both ARN formats: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
         """
         if self.cluster:
             return f"service/{self.cluster}/{self.service_name}"
@@ -106,7 +106,7 @@ class TaskArn(NewOldEcsArnMixin, Arn):
         If the ARN was originally parsed with the cluster name, it will be added to
         the formatted rest.
 
-        .. _both ARN formats: https://www.amazonaws.cn/en/new/2018/amazon-ecs-and-aws-fargate-now-allow-resources-tagging-/
+        .. _both ARN formats: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
         """
         if self.cluster:
             return f"task/{self.cluster}/{self.id}"

--- a/tests/test_arn_ecs.py
+++ b/tests/test_arn_ecs.py
@@ -7,9 +7,17 @@ def test_cluster(make_arn):
     assert result.name == "foo"
 
 
-def test_container_instance(make_arn):
+def test_container_instance_without_cluster(make_arn):
     arn = make_arn("ecs", "container-instance/abc123")
     result = ecs.ContainerInstanceArn(arn)
+    assert result.cluster == ""
+    assert result.id == "abc123"
+
+
+def test_container_instance_with_cluster(make_arn):
+    arn = make_arn("ecs", "container-instance/foo/abc123")
+    result = ecs.ContainerInstanceArn(arn)
+    assert result.cluster == "foo"
     assert result.id == "abc123"
 
 
@@ -35,9 +43,17 @@ def test_service_override_cluster(make_arn):
     assert str(result) == "arn:aws:ecs:us-east-1:123456789:service/foo/servicename"
 
 
-def test_task(make_arn):
+def test_task_without_cluster(make_arn):
     arn = make_arn("ecs", "task/abc123")
     result = ecs.TaskArn(arn)
+    assert result.cluster == ""
+    assert result.id == "abc123"
+
+
+def test_task_with_cluster(make_arn):
+    arn = make_arn("ecs", "task/foo/abc123")
+    result = ecs.TaskArn(arn)
+    assert result.cluster == "foo"
     assert result.id == "abc123"
 
 


### PR DESCRIPTION
Adds support for the new ECS ARN format to Task and Container Instance ARNs (Service was already supported).

Ref: https://aws.amazon.com/blogs/compute/migrating-your-amazon-ecs-deployment-to-the-new-arn-and-resource-id-format-2/